### PR TITLE
ESXi state compared is now against actual state instead of key

### DIFF
--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -980,12 +980,14 @@ def advanced_config(
         if config_input:
             ret["changes"] = {"new": {}}
             # compare with Target State File
+            changes = {}
             for host in esxi_config_old:
-                changes = salt.utils.data.recursive_diff(host, config_input)
-                ret = {"name": name, "result": True,
-                       "comment": "", "changes": changes}
-                ret["comment"] = "Muri & Jordi changes test"
-                return ret
+                # I am assuming config input is the state shared across all hosts. (Verify)
+                changes[host] = salt.utils.data.recursive_diff(
+                    host, config_input)
+            ret = {"name": name, "result": True,
+                   "comment": "I am assuming config input is the state shared across all hosts. (Verify)", "changes": changes}
+            return ret
         else:
             ret["result"] = None
             ret["changes"] = {"new": {}}

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -984,7 +984,7 @@ def advanced_config(
             for host in esxi_config_old:
                 # I am assuming config input is the state shared across all hosts. (Verify)
                 changes[host] = salt.utils.data.recursive_diff(
-                    host, config_input)
+                    esxi_config_old[host], config_input)
             ret = {"name": name, "result": True,
                    "comment": "I am assuming config input is the state shared across all hosts. (Verify)", "changes": changes}
             return ret


### PR DESCRIPTION
The major issue there was is that the comparison was against the key of the dictionary, it should be against the content of it, also only one host was being computed, since the return was inside the for loop. It would be great to test with an actual ESXi config, instead of this firewall_rules