### PR TITLE
Modify existing state functions to match with the SaltStack team convention

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -4,6 +4,9 @@
 Contributing to Salt Extension Modules for VMware
 =================================================
 
+If you just want to get started hacking as quckly as possible, check out the
+`README.md <https://github.com/saltstack/salt-ext-modules-vmware>`_ in the saltext.vmware repo.
+
 * How is the extension module :ref:`released<Release>`?
 
 * What and why were :ref:`architectural decisions` made?

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -8,6 +8,13 @@ for VMware as quick as possible.
 
 .. note::
 
+    This is the quickstart guide for using the module as an end user. If you
+    want to contribute to the project or hack on the module, you'll want to
+    check out the :ref:`contributing` guide. Following these instructions will
+    install the module, but your changes will not be detected.
+
+.. note::
+
     This extension module is currently undergoing rapid changes. If you're
     using it for any production purposes, make sure that you're specifying
     which version of the extension module that you want, and you're testing the

--- a/docs/ref/modules/all.rst
+++ b/docs/ref/modules/all.rst
@@ -13,6 +13,7 @@ Execution Modules
     saltext.vmware.modules.cluster_ha
     saltext.vmware.modules.datacenter
     saltext.vmware.modules.datastore
+    saltext.vmware.modules.dvportgroup
     saltext.vmware.modules.dvswitch
     saltext.vmware.modules.esxi
     saltext.vmware.modules.folder

--- a/docs/ref/modules/saltext.vmware.modules.dvportgroup.rst
+++ b/docs/ref/modules/saltext.vmware.modules.dvportgroup.rst
@@ -1,0 +1,6 @@
+
+saltext.vmware.modules.dvportgroup
+==================================
+
+.. automodule:: saltext.vmware.modules.dvportgroup
+    :members:

--- a/src/saltext/vmware/modules/dvportgroup.py
+++ b/src/saltext/vmware/modules/dvportgroup.py
@@ -1,2 +1,71 @@
-def get(switch_name, portgroup_key, host_name, service_instance, profile):
-    ...  # will be provided by PR 312
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import logging
+
+import saltext.vmware.utils.connect as connect
+import saltext.vmware.utils.vmware as utils_vmware
+
+log = logging.getLogger(__name__)
+
+try:
+    from pyVmomi import vim, vmodl, VmomiSupport
+
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+__virtualname__ = "vmware_dvportgroup"
+__proxyenabled__ = ["vmware_dvportgroup"]
+
+
+def __virtual__():
+    if not HAS_PYVMOMI:
+        return False, "Unable to import pyVmomi module."
+    return __virtualname__
+
+
+def get(switch_name, portgroup_key, host_name=None, service_instance=None, profile=None):
+    """
+    Get distributed portgroup from a distributed switch optionally from a host.
+
+    service_instance
+        Service instance object to access vCenter
+
+    switch_name
+        Name of the distributed switch.
+
+    portgroup_key
+        Portgroup key.
+
+    host_name
+        Name of the ESXi host.  (optional).
+
+    service_instance
+        Use this vCenter service connection instance instead of creating a new one. (optional)
+
+    profile
+        Profile to use (optional)
+    """
+    ret = {}
+
+    service_instance = service_instance or connect.get_service_instance(
+        config=__opts__, profile=profile
+    )
+
+    switch_ref = utils_vmware._get_dvs(service_instance=service_instance, dvs_name=switch_name)
+
+    if switch_ref:
+        for portgroup in switch_ref.portgroup:
+            if portgroup.key == portgroup_key:
+                ret["name"] = portgroup.config.name
+                ret["vlan"] = portgroup.config.defaultPortConfig.vlan.vlanId
+                ret["pnic"] = []
+                if host_name:
+                    for host in portgroup.config.distributedVirtualSwitch.config.host:
+                        if host.config.host.name == host_name:
+                            for pnic in host.config.backing.pnicSpec:
+                                ret["pnic"].append(pnic.pnicDevice)
+
+        ret = json.loads(json.dumps(ret, cls=VmomiSupport.VmomiJSONEncoder))
+    return ret

--- a/src/saltext/vmware/modules/dvportgroup.py
+++ b/src/saltext/vmware/modules/dvportgroup.py
@@ -1,0 +1,2 @@
+def get(switch_name, portgroup_key, host_name, service_instance, profile):
+    ...  # will be provided by PR 312

--- a/src/saltext/vmware/modules/vm.py
+++ b/src/saltext/vmware/modules/vm.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+import json
 import logging
 
 import salt.exceptions
@@ -11,7 +12,7 @@ import saltext.vmware.utils.vm as utils_vm
 log = logging.getLogger(__name__)
 
 try:
-    from pyVmomi import vim
+    from pyVmomi import vim, VmomiSupport
 
     HAS_PYVMOMI = True
 except ImportError:

--- a/src/saltext/vmware/states/drift_report.py
+++ b/src/saltext/vmware/states/drift_report.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from salt.loader.lazy import global_injector_decorator
+import saltext.vmware.states.esxi as esxi
+import saltext.vmware.states.storage_policy as state_storage_policy
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "vmware_drift_report"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def report(name, firewall_config, advanced_config, storage_policy):
+    """
+    Creates drift report
+    policies
+        Policy list to set state to
+    """
+    context = {"__opts__": __opts__, "__salt__": __salt__, "__pillar__": __pillar__}
+    firewall_result = global_injector_decorator(context)(esxi.firewall_config)(**firewall_config)["changes"]
+    advanced_result = global_injector_decorator(context)(esxi.advanced_config)(**advanced_config)["changes"]
+    storage_policy_result = global_injector_decorator(context)(state_storage_policy.storage_policy)(**storage_policy)["changes"]
+
+    esxi_result = {host: {"firewall_config": firewall_result[host],
+                          "advanced_config": advanced_result[host]} for host in firewall_result}
+
+    ret = {"name": name, "result": True, "comment": "",
+           "changes": {"esxi": esxi_result, "storagePolicies": storage_policy_result}}
+    return ret

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -973,8 +973,9 @@ def advanced_config(
     )
     if __opts__["test"]:
         if config_input:
+            changes = {}
             for host in esxi_config_old:
-                changes = salt.utils.data.recursive_diff(esxi_config_old[host], config_input["advanced_options"])["new"]
+                changes[host] = salt.utils.data.recursive_diff(esxi_config_old[host], config_input["advanced_options"])["new"]
                 ret = {"name": name, "result": True,
                        "comment": config_input["advanced_options"], "changes": changes}
                 return ret

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -1102,30 +1102,16 @@ def firewall_config(
                     value[name][i]["allowed_host"])
     old_configs = {}
     for host in hosts:
+        old_configs[host.name] = {}
         for firewall_conf in value[name]:
-            if host.name in old_configs:
-                fw_config = utils_esxi.get_firewall_config(
-                    ruleset_name=firewall_conf["name"],
-                    host_name=host.name,
-                    service_instance=service_instance,
-                )
-                old_configs[host.name][firewall_conf["name"]] = fw_config[host.name][
-                    firewall_conf["name"]
-                ]
-            else:
-                fw_config = utils_esxi.get_firewall_config(
-                    ruleset_name=firewall_conf["name"],
-                    host_name=host.name,
-                    service_instance=service_instance,
-                )
-                old_configs[host.name] = {}
-                old_configs[host.name][firewall_conf["name"]] = fw_config[host.name][
-                    firewall_conf["name"]
-                ]
+            fw_config = utils_esxi.get_firewall_config(
+                ruleset_name=firewall_conf["name"],
+                host_name=host.name,
+                service_instance=service_instance,
+            )
+            old_configs[host.name][firewall_conf["name"]] = fw_config[host.name][firewall_conf["name"]]
 
     if __opts__["test"]:
-        ret["result"] = None
-        ret["changes"] = {}
         for host in hosts:
             ret["changes"][host.name] = {}
             for firewall_config in value[name]:

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -1163,26 +1163,6 @@ def firewall_config(
                                 ] = f"{k} will be set to {firewall_conf[k]}"
                             else:
                                 ret["changes"][host.name][firewall_conf["name"]][k] = firewall_config[k]
-'''
-somestate:
-  vmware_esxi.firewall_config:
-    - config:
-        foo: bar
-        something: else
-        cool: guy
-
-
-changes:
-    foo is already set to bar
-    something will be changed to else
-    cool is already set to guy
-
-
-
-changes:
-    new:
-       {"something": "else"}
-'''
         ret["comment"] = "These options are set to change."
         return ret
 

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -1018,8 +1018,7 @@ def firewall_config(
     cluster_name=None,
     host_name=None,
     service_instance=None,
-    verbose=False,
-    quiet=False
+    less=False
 ):
     """
     Set firewall configuration on matching ESXi hosts.
@@ -1120,12 +1119,12 @@ def firewall_config(
                                 old_configs[host.name][rule][k][j]
                                 == ruleset[k][j]
                             ):
-                                if verbose:
+                                if not less:
                                     ret["changes"][host.name][rule][
                                         j
                                     ] = f"{j} is already set to {ruleset[k][j]}"
                             else:
-                                if verbose:
+                                if not less:
                                     ret["changes"][host.name][rule][
                                         j
                                     ] = f"{j} will be set to {ruleset[k][j]}"
@@ -1133,12 +1132,12 @@ def firewall_config(
                                     ret["changes"][host.name][rule][j] = ruleset[k][j]
                     else:
                         if old_configs[host.name][rule][k] == ruleset[k]:
-                            if verbose:
+                            if not less:
                                 ret["changes"][host.name][rule][
                                     k
                                 ] = f"{k} is already set to {ruleset[k]}"
                         else:
-                            if verbose:
+                            if not less:
                                 ret["changes"][host.name][rule][
                                     k
                                 ] = f"{k} will be set to {ruleset[k]}"

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -962,13 +962,8 @@ def advanced_config(
     log.debug("Running vmware_esxi.advanced_config")
     ret = {"name": name, "result": None, "comment": "", "changes": {}}
     if not service_instance:
-        #print("config = ", __opts__)
-        log.warn("config %r", __opts__)
         service_instance = get_service_instance(config=__opts__)
-        # service_instance = get_service_instance(
-        #   config=__opts__, pillar=__pillar__)
-
-    #import pdb; pdb.set_trace()
+        
     esxi_config_old = __salt__["vmware_esxi.get_advanced_config"](
         config_name=name,
         datacenter_name=datacenter_name,

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -1085,7 +1085,7 @@ def firewall_config(
     ret = {"name": name, "result": None, "comment": "", "changes": {}}
     if not service_instance:
         service_instance = get_service_instance(
-            config=__opts__, pillar=__pillar__)
+            config=__opts__)
 
     hosts = utils_esxi.get_hosts(
         service_instance=service_instance,

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -956,6 +956,8 @@ def firewall_config(
     cluster_name=None,
     host_name=None,
     service_instance=None,
+    verbose=False,
+    quiet=False
 ):
     """
     Set firewall configuration on matching ESXi hosts.
@@ -977,6 +979,32 @@ def firewall_config(
 
     service_instance
         Use this vCenter service connection instance instead of creating a new one. (optional).
+
+    verbose
+        Default False. If this is set to True, in test mode show which values
+        are already correct as well as which values will be changed.
+
+    less
+        Default False. If this is set to True, only the changed values will be reported. For example
+
+        .. code-block:: yaml
+
+            Set firewall config:
+              vmware_esxi.firewall_config:
+                - name: example
+                - config:
+                    foo: bar
+                    quux: bang
+
+        If the existing config was ``{"foo": "bar", "quux": "fnord"}`` then the output would be:
+
+        .. code-block:
+
+            Set firewall config:
+            ...
+            changes:
+              {"quux": "bang"}
+
 
     .. code-block:: yaml
 
@@ -1040,22 +1068,50 @@ def firewall_config(
                                 old_configs[host.name][firewall_config["name"]][k][j]
                                 == firewall_conf[k][j]
                             ):
-                                ret["changes"][host.name][firewall_config["name"]][
-                                    j
-                                ] = f"{j} is already set to {firewall_conf[k][j]}"
+                                if verbose:
+                                    ret["changes"][host.name][firewall_config["name"]][
+                                        j
+                                    ] = f"{j} is already set to {firewall_conf[k][j]}"
                             else:
-                                ret["changes"][host.name][firewall_config["name"]][
-                                    j
-                                ] = f"{j} will be set to {firewall_conf[k][j]}"
+                                if verbose:
+                                    ret["changes"][host.name][firewall_config["name"]][
+                                        j
+                                    ] = f"{j} will be set to {firewall_conf[k][j]}"
+                                else:
+                                    ret["changes"][host.name][firewall_conf["name"]][j] = firewall_config[k][j]
                     else:
                         if old_configs[host.name][firewall_config["name"]][k] == firewall_conf[k]:
-                            ret["changes"][host.name][firewall_config["name"]][
-                                k
-                            ] = f"{k} is already set to {firewall_conf[k]}"
+                            if verbose:
+                                ret["changes"][host.name][firewall_config["name"]][
+                                    k
+                                ] = f"{k} is already set to {firewall_conf[k]}"
                         else:
-                            ret["changes"][host.name][firewall_config["name"]][
-                                k
-                            ] = f"{k} will be set to {firewall_conf[k]}"
+                            if verbose:
+                                ret["changes"][host.name][firewall_config["name"]][
+                                    k
+                                ] = f"{k} will be set to {firewall_conf[k]}"
+                            else:
+                                ret["changes"][host.name][firewall_conf["name"]][k] = firewall_config[k]
+'''
+somestate:
+  vmware_esxi.firewall_config:
+    - config:
+        foo: bar
+        something: else
+        cool: guy
+
+
+changes:
+    foo is already set to bar
+    something will be changed to else
+    cool is already set to guy
+
+
+
+changes:
+    new:
+       {"something": "else"}
+'''
         ret["comment"] = "These options are set to change."
         return ret
 

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -976,9 +976,9 @@ def advanced_config(
             changes = {}
             for host in esxi_config_old:
                 changes[host] = salt.utils.data.recursive_diff(esxi_config_old[host], config_input["advanced_options"])["new"]
-                ret = {"name": name, "result": True,
+            ret = {"name": name, "result": True,
                        "comment": config_input["advanced_options"], "changes": changes}
-                return ret
+            return ret
         else:
             ret["result"] = None
             ret["changes"] = {"new": {}}

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -963,7 +963,7 @@ def advanced_config(
     ret = {"name": name, "result": None, "comment": "", "changes": {}}
     if not service_instance:
         service_instance = get_service_instance(config=__opts__)
-        
+
     esxi_config_old = __salt__["vmware_esxi.get_advanced_config"](
         config_name=name,
         datacenter_name=datacenter_name,
@@ -973,13 +973,10 @@ def advanced_config(
     )
     if __opts__["test"]:
         if config_input:
-            ret["changes"] = {"new": {}}
-            # compare with Target State File
             for host in esxi_config_old:
-                changes = salt.utils.data.recursive_diff(host, config_input)
+                changes = salt.utils.data.recursive_diff(esxi_config_old[host], config_input["advanced_options"])["new"]
                 ret = {"name": name, "result": True,
-                       "comment": "", "changes": changes}
-                ret["comment"] = "Muri & Jordi changes test"
+                       "comment": config_input["advanced_options"], "changes": changes}
                 return ret
         else:
             ret["result"] = None

--- a/src/saltext/vmware/states/storage_policy.py
+++ b/src/saltext/vmware/states/storage_policy.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+import saltext.vmware.utils.connect as connect
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "vsphere_storage_policy"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def storage_policy(name, storagePolicies):
+    """
+    Checks state of storage policy of each host
+    policies
+        Policy list to set state to
+    """
+
+    res = connect.request(
+        "/api/vcenter/storage/policies", "GET", opts=__opts__, pillar=__pillar__
+    )
+    response = res["response"].json()
+    current_policies = list(map(lambda p: p['name'], response))
+    changes = []
+    for policy in storagePolicies:
+        if policy['policyName'] not in current_policies:
+            changes.append(policy['policyName'])
+
+    ret = {"name": name, "result": True, "comment": "",
+           "changes": changes}
+    return ret

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -88,3 +88,19 @@ def mock_http_error():
     http_error_obj.response = error_obj_response
     http_error_obj.request = error_obj_request
     yield http_error_obj
+
+
+@pytest.fixture(params=(True, False))
+def fake_service_instance(request):
+    # This fixture should be used for all unit tests where a service instance
+    # is needed. It will test both scenarios where the service instance is
+    # provided, or not.
+    provide_service_instance = request.param
+    with patch("saltext.vmware.utils.connect.get_service_instance", autospec=True) as fake_get_si:
+        if not provide_service_instance:
+            fake_get_si.side_effect = Exception(
+                "get_service instance was unexpectedly called in a test"
+            )
+            yield fake_get_si, fake_get_si.return_value
+        else:
+            yield fake_get_si, None

--- a/tests/unit/modules/test_dvportgroup.py
+++ b/tests/unit/modules/test_dvportgroup.py
@@ -1,0 +1,255 @@
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+import saltext.vmware.modules.dvportgroup as dvportgroup
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {dvportgroup: {}}
+
+
+def mock_with_name(name, *args, **kwargs):
+    # Can't mock name via constructor: https://docs.python.org/3/library/unittest.mock.html#mock-names-and-the-name-attribute
+    mock = Mock(*args, **kwargs)
+    mock.name = name
+    return mock
+
+
+@pytest.fixture(
+    params=(
+        # no data returned
+        {
+            "expected": {},
+            "contents": [],
+            "view_data": [],
+            "switch_name": "fnord",
+            "portgroup_key": "fnord",
+        },
+        # data, but missing target
+        # TODO
+        {
+            "expected": {},
+            "contents": [],
+            "view_data": [
+                mock_with_name(name="definitely not the switch_name", portgroup=[]),
+            ],
+            "switch_name": "not anything in the contents",
+            "portgroup_key": "fnord",
+        },
+        # only target data returned - no pnic
+        {
+            "switch_name": "the name of the switch",
+            "portgroup_key": "the key of the portgroup",
+            "expected": {
+                "name": "what even ever",
+                "vlan": "the id of the vlan",
+                "pnic": [],
+            },
+            "contents": [
+                Mock(
+                    propSet=[
+                        mock_with_name(
+                            name="name", val="the name of the switch", obj="something unimportant"
+                        ),
+                        mock_with_name(
+                            name="whatever", val="some other prop", obj="something unimportant"
+                        ),
+                        mock_with_name(
+                            name="coolprop", val="subzero or something", obj="something unimportant"
+                        ),
+                    ]
+                )
+            ],
+            "view_data": [
+                mock_with_name(
+                    name="the name of the switch",
+                    portgroup=[
+                        Mock(
+                            key="the key of the portgroup",
+                            config=mock_with_name(
+                                name="what even ever",
+                                defaultPortConfig=Mock(vlan=Mock(vlanId="the id of the vlan")),
+                            ),
+                        ),
+                    ],
+                )
+            ],
+        },
+        # only target data returned - non-matching pnic data
+        # TODO
+        {
+            "switch_name": "the name of the switch",
+            "portgroup_key": "the key of the portgroup",
+            "host_name": "host name that does not match",
+            "expected": {
+                "name": "what even ever",
+                "vlan": "the id of the vlan",
+                "pnic": [],
+            },
+            "contents": [
+                Mock(
+                    propSet=[
+                        mock_with_name(
+                            name="name", val="the name of the switch", obj="something unimportant"
+                        ),
+                        mock_with_name(
+                            name="whatever", val="some other prop", obj="something unimportant"
+                        ),
+                        mock_with_name(
+                            name="coolprop", val="subzero or something", obj="something unimportant"
+                        ),
+                    ]
+                )
+            ],
+            "view_data": [
+                mock_with_name(
+                    name="the name of the switch",
+                    portgroup=[
+                        Mock(
+                            key="the key of the portgroup",
+                            config=mock_with_name(
+                                name="what even ever",
+                                defaultPortConfig=Mock(vlan=Mock(vlanId="the id of the vlan")),
+                                distributedVirtualSwitch=Mock(
+                                    config=Mock(
+                                        host=[
+                                            Mock(
+                                                config=Mock(
+                                                    host=mock_with_name(
+                                                        name="this definitely doesn't match what they're looking for"
+                                                    ),
+                                                    backing=Mock(
+                                                        pnicSpec=[
+                                                            Mock(pnicDevice="one"),
+                                                            Mock(pnicDevice="two"),
+                                                            Mock(pnicDevice="three"),
+                                                        ]
+                                                    ),
+                                                )
+                                            ),
+                                        ]
+                                    )
+                                ),
+                            ),
+                        ),
+                    ],
+                )
+            ],
+        },
+        # only target data returned - matching pnic data
+        {
+            "switch_name": "the name of the switch",
+            "portgroup_key": "the key of the portgroup",
+            "host_name": "roscivs",
+            "expected": {
+                "name": "what even ever",
+                "vlan": "the id of the vlan",
+                # matches the pnicDevice's in the view_data mocks
+                "pnic": ["one", "two", "three"],
+            },
+            "contents": [
+                Mock(
+                    propSet=[
+                        mock_with_name(
+                            name="name", val="the name of the switch", obj="something unimportant"
+                        ),
+                        mock_with_name(
+                            name="whatever", val="some other prop", obj="something unimportant"
+                        ),
+                        mock_with_name(
+                            name="coolprop", val="subzero or something", obj="something unimportant"
+                        ),
+                    ]
+                )
+            ],
+            "view_data": [
+                mock_with_name(
+                    name="the name of the switch",
+                    portgroup=[
+                        Mock(
+                            key="the key of the portgroup",
+                            config=mock_with_name(
+                                name="what even ever",
+                                defaultPortConfig=Mock(vlan=Mock(vlanId="the id of the vlan")),
+                                distributedVirtualSwitch=Mock(
+                                    config=Mock(
+                                        host=[
+                                            Mock(
+                                                config=Mock(
+                                                    host=mock_with_name(name="roscivs"),
+                                                    backing=Mock(
+                                                        pnicSpec=[
+                                                            Mock(pnicDevice="one"),
+                                                            Mock(pnicDevice="two"),
+                                                            Mock(pnicDevice="three"),
+                                                        ]
+                                                    ),
+                                                )
+                                            ),
+                                        ]
+                                    )
+                                ),
+                            ),
+                        ),
+                    ],
+                )
+            ],
+        },
+        #    {'expected': Mock(view=[mock_with_name(name='dude')]),
+        # 'contents': [Mock
+        # target data returned and then some
+        # TODO
+        # multiple matching targets
+        # TODO
+    )
+)
+def mocked_dvportgroup_data(request, fake_service_instance):
+    fake_get_service_instance, _ = fake_service_instance
+    fake_get_service_instance.return_value.content.propertyCollector.RetrieveContents.return_value = request.param[
+        "contents"
+    ]
+    fake_get_service_instance.return_value.RetrieveContent.return_value.viewManager.CreateContainerView.return_value = Mock(
+        view=request.param["view_data"]
+    )
+
+    with patch("pyVmomi.vmodl.query.PropertyCollector.ObjectSpec", autospec=True) as fake_obj_spec:
+        yield request.param["switch_name"], request.param["portgroup_key"], request.param.get(
+            "host_name"
+        ), request.param["expected"]
+
+
+@pytest.mark.xfail
+def test_dvportgroup_get_should_return_expected_data(
+    mocked_dvportgroup_data, fake_service_instance
+):
+    _, service_instance = fake_service_instance
+    switch_name, portgroup_key, host_name, expected_data = mocked_dvportgroup_data
+    ret = dvportgroup.get(
+        switch_name=switch_name,
+        portgroup_key=portgroup_key,
+        host_name=host_name,
+        service_instance=service_instance,
+        profile="bob",
+    )
+    assert ret == expected_data
+
+
+@pytest.mark.xfail
+def test_get_should_feed_results_through_VmomiJSONEncoder():
+    expected_data = {"blerp": "lawl"}
+    with patch("saltext.vmware.utils.vmware._get_dvs", autospec=True) as fake_dvs, patch(
+        "pyVmomi.VmomiSupport.VmomiJSONEncoder", autospec=True
+    ) as fake_encoder:
+        fake_dvs.return_value.portgroup = []
+        fake_encoder.return_value.encode.return_value = '{"blerp": "lawl"}'
+        ret = dvportgroup.get(
+            switch_name="fnord",
+            portgroup_key="fnord",
+            host_name="fnord",
+            service_instance="fnord",
+            profile="bob",
+        )
+        assert ret == expected_data

--- a/tests/unit/modules/test_dvportgroup.py
+++ b/tests/unit/modules/test_dvportgroup.py
@@ -221,7 +221,6 @@ def mocked_dvportgroup_data(request, fake_service_instance):
         ), request.param["expected"]
 
 
-@pytest.mark.xfail
 def test_dvportgroup_get_should_return_expected_data(
     mocked_dvportgroup_data, fake_service_instance
 ):
@@ -237,7 +236,6 @@ def test_dvportgroup_get_should_return_expected_data(
     assert ret == expected_data
 
 
-@pytest.mark.xfail
 def test_get_should_feed_results_through_VmomiJSONEncoder():
     expected_data = {"blerp": "lawl"}
     with patch("saltext.vmware.utils.vmware._get_dvs", autospec=True) as fake_dvs, patch(


### PR DESCRIPTION
For firewall_rules function, the verbosity was adjusted following Wayne and SaltStack team recommendations, for the other two, advanced_options and storage_policies, it was ensured to keep the same format, for compatibility along all JSON report




NOTE: We need to accept this PR on Nov 10 so following work does not contain changes from this task